### PR TITLE
Implementar Navegação entre Telas com Jetpack Compose

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -50,6 +50,8 @@ dependencies {
     implementation(libs.androidx.ui.tooling.preview)
     implementation(libs.androidx.material3)
     implementation (libs.androidx.material.icons.extended)
+    implementation(libs.androidx.navigation.compose)
+    implementation(libs.google.accompanist.navigation.animation)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/app/src/main/java/com/pgmv/bandify/MainActivity.kt
+++ b/app/src/main/java/com/pgmv/bandify/MainActivity.kt
@@ -4,29 +4,52 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.compose.animation.ExperimentalAnimationApi
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.systemBars
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.tooling.preview.Preview
+import com.google.accompanist.navigation.animation.rememberAnimatedNavController
+import com.pgmv.bandify.navigation.NavigationHost
+import com.pgmv.bandify.ui.components.BottomBar
+import com.pgmv.bandify.ui.components.TopBar
 import com.pgmv.bandify.ui.theme.BandifyTheme
 
 class MainActivity : ComponentActivity() {
+    @OptIn(ExperimentalAnimationApi::class)
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
         setContent {
             BandifyTheme {
-                Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
-                    Text(
-                        text = "Hello, Bandify!",
-                        modifier = Modifier.padding(innerPadding)
-                    )
+                val navController = rememberAnimatedNavController()
+                val (screenTitle, setScreenTitle) = remember { mutableStateOf("Home") }
+                val (isHomeScreen, setIsHomeScreen) = remember { mutableStateOf(true) }
+
+                Scaffold(
+                    topBar = {
+                        TopBar(screenTitle = screenTitle, isHomeScreen = isHomeScreen)
+                    },
+                    bottomBar = {
+                        BottomBar(navController = navController)
+                    },
+                    modifier = Modifier.windowInsetsPadding(WindowInsets.systemBars)
+                ) { innerPadding ->
+                    Surface(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .padding(innerPadding)
+                    ) {
+                        NavigationHost(navController, setScreenTitle, setIsHomeScreen)
+                    }
                 }
             }
         }
     }
 }
-

--- a/app/src/main/java/com/pgmv/bandify/navigation/NavigationHost.kt
+++ b/app/src/main/java/com/pgmv/bandify/navigation/NavigationHost.kt
@@ -8,6 +8,7 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import com.google.accompanist.navigation.animation.AnimatedNavHost
 import com.google.accompanist.navigation.animation.composable
+import com.pgmv.bandify.navigation.utils.getScreenTitle
 import com.pgmv.bandify.ui.screen.AgendaScreen
 import com.pgmv.bandify.ui.screen.ArquivosScreen
 import com.pgmv.bandify.ui.screen.HomeScreen
@@ -17,7 +18,8 @@ import com.pgmv.bandify.ui.screen.RepertorioScreen
 @OptIn(ExperimentalAnimationApi::class)
 private fun NavGraphBuilder.addScreen(
     route: String,
-    setIsHomeScreen: (Boolean) -> Unit,
+    setScreenTitle: (String) -> Unit,
+    setHomeScreen: (Boolean) -> Unit,
     content: @Composable () -> Unit
 ) {
     composable(
@@ -27,7 +29,8 @@ private fun NavGraphBuilder.addScreen(
         popEnterTransition = { fadeIn() },
         popExitTransition = { fadeOut() }
     ) {
-        setIsHomeScreen(route == "home")
+        setScreenTitle(getScreenTitle(route))
+        setHomeScreen(route == "home")
         content()
     }
 }
@@ -37,23 +40,23 @@ private fun NavGraphBuilder.addScreen(
 fun NavigationHost(
     navController: NavHostController,
     setScreenTitle: (String) -> Unit,
-    setIsHomeScreen: (Boolean) -> Unit
+    setHomeScreen: (Boolean) -> Unit
 ) {
     AnimatedNavHost(navController = navController, startDestination = "home") {
-        addScreen("home", setIsHomeScreen) {
-            HomeScreen(setScreenTitle)
+        addScreen("home", setScreenTitle, setHomeScreen) {
+            HomeScreen()
         }
-        addScreen("agenda", setIsHomeScreen) {
-            AgendaScreen(setScreenTitle)
+        addScreen("agenda", setScreenTitle, setHomeScreen) {
+            AgendaScreen()
         }
-        addScreen("repertório", setIsHomeScreen) {
-            RepertorioScreen(setScreenTitle)
+        addScreen("repertório", setScreenTitle, setHomeScreen) {
+            RepertorioScreen()
         }
-        addScreen("arquivos", setIsHomeScreen) {
-            ArquivosScreen(setScreenTitle)
+        addScreen("arquivos", setScreenTitle, setHomeScreen) {
+            ArquivosScreen()
         }
-        addScreen("perfil", setIsHomeScreen) {
-            PerfilScreen(setScreenTitle)
+        addScreen("perfil", setScreenTitle, setHomeScreen) {
+            PerfilScreen()
         }
     }
 }

--- a/app/src/main/java/com/pgmv/bandify/navigation/NavigationHost.kt
+++ b/app/src/main/java/com/pgmv/bandify/navigation/NavigationHost.kt
@@ -1,0 +1,59 @@
+package com.pgmv.bandify.navigation
+
+import androidx.compose.animation.ExperimentalAnimationApi
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.runtime.Composable
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavHostController
+import com.google.accompanist.navigation.animation.AnimatedNavHost
+import com.google.accompanist.navigation.animation.composable
+import com.pgmv.bandify.ui.screen.AgendaScreen
+import com.pgmv.bandify.ui.screen.ArquivosScreen
+import com.pgmv.bandify.ui.screen.HomeScreen
+import com.pgmv.bandify.ui.screen.PerfilScreen
+import com.pgmv.bandify.ui.screen.RepertorioScreen
+
+@OptIn(ExperimentalAnimationApi::class)
+private fun NavGraphBuilder.addScreen(
+    route: String,
+    setIsHomeScreen: (Boolean) -> Unit,
+    content: @Composable () -> Unit
+) {
+    composable(
+        route,
+        enterTransition = { fadeIn() },
+        exitTransition = { fadeOut() },
+        popEnterTransition = { fadeIn() },
+        popExitTransition = { fadeOut() }
+    ) {
+        setIsHomeScreen(route == "home")
+        content()
+    }
+}
+
+@OptIn(ExperimentalAnimationApi::class)
+@Composable
+fun NavigationHost(
+    navController: NavHostController,
+    setScreenTitle: (String) -> Unit,
+    setIsHomeScreen: (Boolean) -> Unit
+) {
+    AnimatedNavHost(navController = navController, startDestination = "home") {
+        addScreen("home", setIsHomeScreen) {
+            HomeScreen(setScreenTitle)
+        }
+        addScreen("agenda", setIsHomeScreen) {
+            AgendaScreen(setScreenTitle)
+        }
+        addScreen("repertório", setIsHomeScreen) {
+            RepertorioScreen(setScreenTitle)
+        }
+        addScreen("arquivos", setIsHomeScreen) {
+            ArquivosScreen(setScreenTitle)
+        }
+        addScreen("perfil", setIsHomeScreen) {
+            PerfilScreen(setScreenTitle)
+        }
+    }
+}

--- a/app/src/main/java/com/pgmv/bandify/navigation/utils/getScreenTitle.kt
+++ b/app/src/main/java/com/pgmv/bandify/navigation/utils/getScreenTitle.kt
@@ -1,0 +1,12 @@
+package com.pgmv.bandify.navigation.utils
+
+fun getScreenTitle(route: String): String {
+    return when (route) {
+        "home" -> "Bandify"
+        "agenda" -> "Agenda"
+        "repertório" -> "Repertório"
+        "arquivos" -> "Arquivos"
+        "perfil" -> "Perfil"
+        else -> "Bandify"
+    }
+}

--- a/app/src/main/java/com/pgmv/bandify/ui/components/BottomBar.kt
+++ b/app/src/main/java/com/pgmv/bandify/ui/components/BottomBar.kt
@@ -9,11 +9,8 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.List
 import androidx.compose.material.icons.filled.AccountCircle
-import androidx.compose.material.icons.filled.AudioFile
 import androidx.compose.material.icons.filled.DateRange
-import androidx.compose.material.icons.filled.Email
 import androidx.compose.material.icons.filled.Home
 import androidx.compose.material.icons.filled.LibraryMusic
 import androidx.compose.material.icons.filled.UploadFile
@@ -31,11 +28,13 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
+import androidx.navigation.NavController
+import androidx.navigation.compose.rememberNavController
 
 @Composable
-fun BottomBar() {
+fun BottomBar(navController: NavController) {
     var selectedIndex by remember { mutableIntStateOf(0) }
-    val tabs = listOf("Home", "Calendário", "Repertório", "Arquivos", "Perfil")
+    val tabs = listOf("Home", "Agenda", "Repertório", "Arquivos", "Perfil")
     val icons = listOf(
         Icons.Default.Home,
         Icons.Default.DateRange,
@@ -58,7 +57,16 @@ fun BottomBar() {
 
             Tab(
                 selected = selectedIndex == index,
-                onClick = { selectedIndex = index }
+                onClick = {
+                    selectedIndex = index
+                    navController.navigate(tab){
+                        popUpTo(navController.graph.startDestinationId){
+                            saveState = true
+                        }
+                        launchSingleTop = true
+                        restoreState = true
+                    }
+                }
             ) {
                 Icon(
                     imageVector = icons[index],
@@ -85,5 +93,5 @@ fun BottomBar() {
 @Composable
 @Preview
 fun BottomBarPreview() {
-    BottomBar()
+    BottomBar(rememberNavController())
 }

--- a/app/src/main/java/com/pgmv/bandify/ui/screen/AgendaScreen.kt
+++ b/app/src/main/java/com/pgmv/bandify/ui/screen/AgendaScreen.kt
@@ -5,8 +5,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
 
 @Composable
-fun AgendaScreen(setScreenTitle: (String) -> Unit) {
-    setScreenTitle("Agenda")
+fun AgendaScreen() {
+
     Text(text = "Agenda Screen")
 }
 
@@ -15,5 +15,5 @@ fun AgendaScreen(setScreenTitle: (String) -> Unit) {
     showSystemUi = true)
 @Composable
 fun AgendaScreenPreview() {
-    AgendaScreen(setScreenTitle = {})
+    AgendaScreen()
 }

--- a/app/src/main/java/com/pgmv/bandify/ui/screen/AgendaScreen.kt
+++ b/app/src/main/java/com/pgmv/bandify/ui/screen/AgendaScreen.kt
@@ -1,0 +1,19 @@
+package com.pgmv.bandify.ui.screen
+
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+
+@Composable
+fun AgendaScreen(setScreenTitle: (String) -> Unit) {
+    setScreenTitle("Agenda")
+    Text(text = "Agenda Screen")
+}
+
+@Preview (
+    showBackground = true,
+    showSystemUi = true)
+@Composable
+fun AgendaScreenPreview() {
+    AgendaScreen(setScreenTitle = {})
+}

--- a/app/src/main/java/com/pgmv/bandify/ui/screen/ArquivosScreen.kt
+++ b/app/src/main/java/com/pgmv/bandify/ui/screen/ArquivosScreen.kt
@@ -1,0 +1,19 @@
+package com.pgmv.bandify.ui.screen
+
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+
+@Composable
+fun ArquivosScreen(setScreenTitle: (String) -> Unit) {
+    setScreenTitle("Arquivos")
+    Text(text = "Arquivos Screen")
+}
+
+@Preview (
+    showBackground = true,
+    showSystemUi = true)
+@Composable
+fun ArquivoScreenPreview() {
+    ArquivosScreen(setScreenTitle = {})
+}

--- a/app/src/main/java/com/pgmv/bandify/ui/screen/ArquivosScreen.kt
+++ b/app/src/main/java/com/pgmv/bandify/ui/screen/ArquivosScreen.kt
@@ -5,8 +5,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
 
 @Composable
-fun ArquivosScreen(setScreenTitle: (String) -> Unit) {
-    setScreenTitle("Arquivos")
+fun ArquivosScreen() {
+
     Text(text = "Arquivos Screen")
 }
 
@@ -15,5 +15,5 @@ fun ArquivosScreen(setScreenTitle: (String) -> Unit) {
     showSystemUi = true)
 @Composable
 fun ArquivoScreenPreview() {
-    ArquivosScreen(setScreenTitle = {})
+    ArquivosScreen()
 }

--- a/app/src/main/java/com/pgmv/bandify/ui/screen/HomeScreen.kt
+++ b/app/src/main/java/com/pgmv/bandify/ui/screen/HomeScreen.kt
@@ -1,0 +1,19 @@
+package com.pgmv.bandify.ui.screen
+
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+
+@Composable
+fun HomeScreen(setScreenTitle: (String) -> Unit) {
+    setScreenTitle("Home")
+    Text(text = "Home Screen")
+}
+
+@Preview (
+    showBackground = true,
+    showSystemUi = true)
+@Composable
+fun HomeScreenPreview() {
+    HomeScreen(setScreenTitle = {})
+}

--- a/app/src/main/java/com/pgmv/bandify/ui/screen/HomeScreen.kt
+++ b/app/src/main/java/com/pgmv/bandify/ui/screen/HomeScreen.kt
@@ -5,8 +5,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
 
 @Composable
-fun HomeScreen(setScreenTitle: (String) -> Unit) {
-    setScreenTitle("Home")
+fun HomeScreen() {
     Text(text = "Home Screen")
 }
 
@@ -15,5 +14,5 @@ fun HomeScreen(setScreenTitle: (String) -> Unit) {
     showSystemUi = true)
 @Composable
 fun HomeScreenPreview() {
-    HomeScreen(setScreenTitle = {})
+    HomeScreen()
 }

--- a/app/src/main/java/com/pgmv/bandify/ui/screen/PerfilScreen.kt
+++ b/app/src/main/java/com/pgmv/bandify/ui/screen/PerfilScreen.kt
@@ -5,8 +5,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
 
 @Composable
-fun PerfilScreen(setScreenTitle: (String) -> Unit) {
-    setScreenTitle("Perfil")
+fun PerfilScreen() {
     Text(text = "Perfil Screen")
 }
 
@@ -15,5 +14,5 @@ fun PerfilScreen(setScreenTitle: (String) -> Unit) {
     showSystemUi = true)
 @Composable
 fun PerfilScreenPreview() {
-    PerfilScreen(setScreenTitle = {})
+    PerfilScreen()
 }

--- a/app/src/main/java/com/pgmv/bandify/ui/screen/PerfilScreen.kt
+++ b/app/src/main/java/com/pgmv/bandify/ui/screen/PerfilScreen.kt
@@ -1,0 +1,19 @@
+package com.pgmv.bandify.ui.screen
+
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+
+@Composable
+fun PerfilScreen(setScreenTitle: (String) -> Unit) {
+    setScreenTitle("Perfil")
+    Text(text = "Perfil Screen")
+}
+
+@Preview(
+    showBackground = true,
+    showSystemUi = true)
+@Composable
+fun PerfilScreenPreview() {
+    PerfilScreen(setScreenTitle = {})
+}

--- a/app/src/main/java/com/pgmv/bandify/ui/screen/RepertorioScreen.kt
+++ b/app/src/main/java/com/pgmv/bandify/ui/screen/RepertorioScreen.kt
@@ -5,8 +5,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
 
 @Composable
-fun RepertorioScreen(setScreenTitle: (String) -> Unit) {
-    setScreenTitle("Repertório")
+fun RepertorioScreen() {
     Text(text = "Repertório Screen")
 }
 
@@ -15,5 +14,5 @@ fun RepertorioScreen(setScreenTitle: (String) -> Unit) {
     showSystemUi = true)
 @Composable
 fun RepertorioScreenPreview() {
-    RepertorioScreen(setScreenTitle = {})
+    RepertorioScreen()
 }

--- a/app/src/main/java/com/pgmv/bandify/ui/screen/RepertorioScreen.kt
+++ b/app/src/main/java/com/pgmv/bandify/ui/screen/RepertorioScreen.kt
@@ -1,0 +1,19 @@
+package com.pgmv.bandify.ui.screen
+
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+
+@Composable
+fun RepertorioScreen(setScreenTitle: (String) -> Unit) {
+    setScreenTitle("Repertório")
+    Text(text = "Repertório Screen")
+}
+
+@Preview (
+    showBackground = true,
+    showSystemUi = true)
+@Composable
+fun RepertorioScreenPreview() {
+    RepertorioScreen(setScreenTitle = {})
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,8 @@
 [versions]
+accompanistNavigationAnimationVersion = "0.31.2-alpha"
+accompanistSystemuicontrollerVersion = "0.24.13-rc"
 agp = "8.7.3"
+coilCompose = "3.0.4"
 kotlin = "2.0.0"
 coreKtx = "1.15.0"
 junit = "4.13.2"
@@ -9,10 +12,17 @@ lifecycleRuntimeKtx = "2.6.1"
 activityCompose = "1.9.3"
 composeBom = "2024.04.01"
 materialIconsExtended = "<1.5.0-beta01>"
+navigationCompose = "2.8.5"
 
 [libraries]
+accompanist-navigation-animation = { module = "com.google.accompanist:accompanist-navigation-animation" }
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
 androidx-material-icons-extended = { module = "androidx.compose.material:material-icons-extended", version.ref = "materialIconsExtended" }
+androidx-navigation-compose = { module = "androidx.navigation:navigation-compose", version.ref = "navigationCompose" }
+coil-compose = { module = "io.coil-kt.coil3:coil-compose", version.ref = "coilCompose" }
+coil-network-okhttp = { module = "io.coil-kt.coil3:coil-network-okhttp", version.ref = "coilCompose" }
+google-accompanist-navigation-animation = { module = "com.google.accompanist:accompanist-navigation-animation", version.ref = "accompanistNavigationAnimationVersion" }
+google-accompanist-systemuicontroller = { module = "com.google.accompanist:accompanist-systemuicontroller", version.ref = "accompanistSystemuicontrollerVersion" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }


### PR DESCRIPTION
### O que foi feito:

- Introduzido o composable NavigationHost para centralizar a lógica de navegação.
- Integrado o AnimatedNavHost para transições de telas com animações fadeIn e fadeOut.
- Definidas as rotas para as telas "Home", "Agenda", "Repertório", "Arquivos" e "Perfil".
- Adicionadas implementações de tela placeholder para testar a navegação.