### PR TITLE
Fix: Ajustar espaçamento e outros detalhes na Home Screen

### DIFF
--- a/app/src/main/java/com/pgmv/bandify/ui/components/HomeActivityCard.kt
+++ b/app/src/main/java/com/pgmv/bandify/ui/components/HomeActivityCard.kt
@@ -25,6 +25,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -51,13 +52,13 @@ fun HomeActivityCard(
             verticalAlignment = Alignment.CenterVertically,
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(horizontal = 12.dp, vertical = 16.dp),
+                .padding(8.dp),
             horizontalArrangement = Arrangement.Center,
         ) {
             Icon(
                 imageVector = if(activity.activityType == "song") Icons.Default.MusicNote else if(activity.activityType == "file") Icons.Default.FileCopy else Icons.Default.Event,
                 contentDescription = "Tipo de atividade",
-                Modifier.size(32.dp).weight(0.5F),
+                Modifier.size(24.dp).weight(0.5F),
             )
             Row (
                 modifier = Modifier.weight(2.5F).padding(start = 8.dp),
@@ -77,7 +78,7 @@ fun HomeActivityCard(
                     )
                     Text(
                         text = activity.itemName,
-                        style = MaterialTheme.typography.titleLarge,
+                        style = MaterialTheme.typography.titleMedium,
                         fontWeight = FontWeight(700),
                         color = MaterialTheme.colorScheme.onSecondary
                     )
@@ -90,7 +91,8 @@ fun HomeActivityCard(
                 fontSize = 8.sp,
                 fontWeight = FontWeight(700),
                 color = Grey40,
-                modifier = Modifier.weight(1F).padding(4.dp)
+                modifier = Modifier.weight(1F).padding(4.dp),
+                textAlign = TextAlign.Center
             )
             IconButton(
                 onClick = { /*TODO*/ },
@@ -100,7 +102,7 @@ fun HomeActivityCard(
                     imageVector = if (activity.activityType == "song" || activity.activityType == "file") Icons.Default.Download else Icons.Default.RemoveRedEye,
                     contentDescription = if (activity.activityType == "song" || activity.activityType == "file") "Baixar arquivo" else "Visualizar evento",
                     tint = MaterialTheme.colorScheme.onSecondary,
-                    modifier = Modifier.size(32.dp)
+                    modifier = Modifier.size(24.dp)
                 )
             }
 

--- a/app/src/main/java/com/pgmv/bandify/ui/screen/HomeScreen.kt
+++ b/app/src/main/java/com/pgmv/bandify/ui/screen/HomeScreen.kt
@@ -1,29 +1,26 @@
 package com.pgmv.bandify.ui.screen
 
-import androidx.compose.foundation.layout.Arrangement
+import android.widget.Space
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import com.pgmv.bandify.database.DatabaseHelper
 import com.pgmv.bandify.ui.components.HomeActivityCard
 import com.pgmv.bandify.ui.components.HomeEventCard
-import com.pgmv.bandify.ui.theme.BandifyTheme
 import com.pgmv.bandify.ui.theme.Grey60
 import java.time.LocalDate
 
@@ -35,6 +32,7 @@ fun HomeScreen(dbHelper: DatabaseHelper? = null, navController: NavController) {
         ?.collectAsState(initial = emptyList())
     val recentActivities = activityHistoryDao?.getRecentActivitiesByUserId(1)?.collectAsState(initial = emptyList())
 
+    val parentHeight = LocalConfiguration.current.screenHeightDp.dp
     Column(
         modifier = Modifier.fillMaxWidth().padding(32.dp)
     ) {
@@ -42,52 +40,62 @@ fun HomeScreen(dbHelper: DatabaseHelper? = null, navController: NavController) {
             text = "Próximos eventos",
             style = MaterialTheme.typography.titleLarge
         )
-        LazyColumn (
-            modifier = Modifier.weight(2F).fillMaxWidth()
+        Spacer(modifier = Modifier.padding(8.dp))
+        Column(
+            modifier = Modifier.fillMaxWidth().height(parentHeight.div(2)),
         ) {
-            if (nextFiveEvents != null) {
-                if (nextFiveEvents.value.isEmpty()) {
+            LazyColumn (
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                if (nextFiveEvents != null) {
+                    if (nextFiveEvents.value.isEmpty()) {
+                        item {
+                            Text(
+                                modifier = Modifier.padding(16.dp),
+                                text = "Nenhum evento encontrado",
+                                style = MaterialTheme.typography.bodyLarge,
+                                color = Grey60
+                            )
+                        }
+                    } else {
+                        items(nextFiveEvents.value) { event ->
+                            HomeEventCard(event = event)
+                            Spacer(modifier = Modifier.padding(4.dp))
+                        }
+                    }
+                } else {
                     item {
                         Text(
                             modifier = Modifier.padding(16.dp),
-                            text = "Nenhum evento encontrado",
+                            text = "Carregando...",
                             style = MaterialTheme.typography.bodyLarge,
                             color = Grey60
                         )
                     }
-                } else {
-                    items(nextFiveEvents.value) { event ->
-                        HomeEventCard(event = event)
-                    }
                 }
-            } else {
-                item {
-                    Text(
-                        modifier = Modifier.padding(16.dp),
-                        text = "Carregando...",
-                        style = MaterialTheme.typography.bodyLarge,
-                        color = Grey60
-                    )
-                }
+
+            }
+            TextButton(
+                onClick = { navController.navigate("agenda") {
+                    popUpTo("home") { inclusive = true }
+                    launchSingleTop = true
+                } },
+                modifier = Modifier.align(Alignment.End),
+            ) {
+                Text(
+                    text = "Ir para agenda",
+                )
             }
         }
-        TextButton(
-            onClick = { navController.navigate("agenda") {
-                popUpTo("home") { inclusive = true }
-                launchSingleTop = true
-            } },
-            modifier = Modifier.align(Alignment.End),
-        ) {
-            Text(
-                text = "Ir para agenda",
-            )
-        }
+
+
         Text(
             text = "Atividades Recentes",
             style = MaterialTheme.typography.titleLarge
         )
+        Spacer(modifier = Modifier.padding(8.dp))
         LazyColumn (
-            modifier = Modifier.weight(1F).fillMaxWidth(),
+            modifier = Modifier.fillMaxWidth(),
         ) {
             if (recentActivities != null) {
                 if (recentActivities.value.isEmpty()) {
@@ -104,7 +112,7 @@ fun HomeScreen(dbHelper: DatabaseHelper? = null, navController: NavController) {
                         HomeActivityCard(
                             activity = activity,
                         )
-                        Spacer(modifier = Modifier.padding(8.dp))
+                        Spacer(modifier = Modifier.padding(4.dp))
                     }
                 }
             } else {


### PR DESCRIPTION
### O que foi feito:

- Ajustado espaçamento entre cartões de evento e de atividade
- Ajustado tamanho dos cartões de atividade e do título da atividade
- Centralizado a informação de tempo do cartão de atividade
- Ajustada a posição do botão de texto que leva para a agenda